### PR TITLE
Fix email module

### DIFF
--- a/auth0-email.tf
+++ b/auth0-email.tf
@@ -1,12 +1,14 @@
-module "email" {
+module "auth0-email" {
   source   = "./modules/auth0-email"
-  for_each = { for k, v in var.emails : k => v }
+  for_each = { for v in var.emails : v.name => v }
 
+  name = each.value.name
   default_from_address = each.value.default_from_address
   credentials = {
-    access_key_id     = each.value.access_key_id
-    secret_access_key = each.value.secret_access_key
-    region            = each.value.region
+    access_key_id     = lookup(each.value, "access_key_id", null)
+    secret_access_key = lookup(each.value, "secret_access_key", null)
+    region            = lookup(each.value, "region", null)
+    api_key           = lookup(each.value, "api_key", null)
   }
   create_template = lookup(each.value,"create_template",false)
   email_template = lookup(each.value,"email_template","")
@@ -16,5 +18,5 @@ module "email" {
   subject = lookup(each.value,"subject","")
   syntax = lookup(each.value,"syntax","liquid")
   url_lifetime_in_seconds = lookup(each.value,"url_lifetime_in_seconds",604800)
-  enbale_teplate = lookup(each.value,"enbale_teplate",true)
+  enable_template = lookup(each.value,"enable_template",true)
 }

--- a/auth0-email.tf
+++ b/auth0-email.tf
@@ -2,7 +2,8 @@ module "auth0-email" {
   source   = "./modules/auth0-email"
   for_each = { for v in var.emails : v.name => v }
 
-  name = each.value.name
+  # auth0_email resource
+  name                 = each.value.name
   default_from_address = each.value.default_from_address
   credentials = {
     access_key_id     = lookup(each.value, "access_key_id", null)
@@ -10,13 +11,7 @@ module "auth0-email" {
     region            = lookup(each.value, "region", null)
     api_key           = lookup(each.value, "api_key", null)
   }
-  create_template = lookup(each.value,"create_template",false)
-  email_template = lookup(each.value,"email_template","")
-  body_template = lookup(each.value,"body_template","")
-  from = lookup(each.value,"from","")
-  result_url = lookup(each.value,"result_url","")
-  subject = lookup(each.value,"subject","")
-  syntax = lookup(each.value,"syntax","liquid")
-  url_lifetime_in_seconds = lookup(each.value,"url_lifetime_in_seconds",604800)
-  enable_template = lookup(each.value,"enable_template",true)
+
+  # auth0_email_template resource
+  templates = lookup(each.value, "templates", {})
 }

--- a/modules/auth0-email/README.md
+++ b/modules/auth0-email/README.md
@@ -5,13 +5,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_auth0"></a> [auth0](#requirement\_auth0) | ~>0.37.1 |
+| <a name="requirement_auth0"></a> [auth0](#requirement\_auth0) | ~>0.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_auth0"></a> [auth0](#provider\_auth0) | ~>0.37.1 |
+| <a name="provider_auth0"></a> [auth0](#provider\_auth0) | ~>0.40.0 |
 
 ## Modules
 
@@ -21,7 +21,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [auth0_email.amazon_ses_email_provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/email) | resource |
+| [auth0_email.this](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/email) | resource |
+| [auth0_email_template.this](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/email_template) | resource |
 
 ## Inputs
 
@@ -29,7 +30,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_credentials"></a> [credentials](#input\_credentials) | Configuration settings for the credentials for the email provider. | <pre>object({<br>    access_key_id     = string<br>    secret_access_key = string<br>    region            = string<br>  })</pre> | n/a | yes |
 | <a name="input_default_from_address"></a> [default\_from\_address](#input\_default\_from\_address) | Default from address for emails | `string` | n/a | yes |
-| <a name="input_enable_ses_email_provider"></a> [enable\_ses\_email\_provider](#input\_enable\_ses\_email\_provider) | n/a | `bool` | `true` | no |
+| <a name="input_enable_provider"></a> [enable\_provider](#input\_enable\_provider) | n/a | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/auth0-email/main.tf
+++ b/modules/auth0-email/main.tf
@@ -1,19 +1,19 @@
-# This is set up the email provider with Amazon SES
-resource "auth0_email" "amazon_ses_email_provider" {
-  name                 = "ses"
-  enabled              = var.enable_ses_email_provider
+resource "auth0_email" "this" {
+  name                 = var.name
+  enabled              = var.enable_provider
   default_from_address = var.default_from_address
 
   credentials {
     access_key_id     = var.credentials.access_key_id
     secret_access_key = var.credentials.secret_access_key
     region            = var.credentials.region
+    api_key           = var.credentials.api_key
   }
 }
 
-resource "auth0_email_template" "my_email_template" {
+resource "auth0_email_template" "this" {
   count       = var.create_template ? 1 : 0
-  depends_on = [auth0_email.amazon_ses_email_provider]
+  depends_on = [auth0_email.this]
 
   template                = var.email_template
   body                    = var.body_template
@@ -22,5 +22,5 @@ resource "auth0_email_template" "my_email_template" {
   subject                 = var.subject
   syntax                  = var.syntax
   url_lifetime_in_seconds = var.url_lifetime_in_seconds
-  enabled                 = var.enbale_teplate
+  enabled                 = var.enable_template
 }

--- a/modules/auth0-email/main.tf
+++ b/modules/auth0-email/main.tf
@@ -12,15 +12,17 @@ resource "auth0_email" "this" {
 }
 
 resource "auth0_email_template" "this" {
-  count       = var.create_template ? 1 : 0
   depends_on = [auth0_email.this]
 
-  template                = var.email_template
-  body                    = var.body_template
-  from                    = var.from
-  result_url              = var.result_url
-  subject                 = var.subject
-  syntax                  = var.syntax
-  url_lifetime_in_seconds = var.url_lifetime_in_seconds
-  enabled                 = var.enable_template
+  for_each = var.templates
+
+  template                  = each.value.template
+  enabled                   = each.value.enabled
+  body                      = each.value.body
+  from                      = each.value.from
+  subject                   = each.value.subject
+  syntax                    = each.value.syntax
+  include_email_in_redirect = each.value.include_email_in_redirect
+  result_url                = each.value.result_url
+  url_lifetime_in_seconds   = each.value.url_lifetime_in_seconds
 }

--- a/modules/auth0-email/variable.tf
+++ b/modules/auth0-email/variable.tf
@@ -24,49 +24,17 @@ variable "credentials" {
   description = "Configuration settings for the credentials for the email provider."
 }
 
-// Template
-variable "create_template" {
-  type = bool
-  default = false
-}
-
-variable "email_template" {
-  type = string
-  description = "Email template name"
-}
-
-variable "body_template" {
-  type = string
-  description = "Body of the email template."
-}
-
-variable "from" {
-  type = string
-  description = "Email address to use as the sender."
-}
-
-variable "result_url" {
-    type = string
-    description = "URL to redirect the user to after a successful action"
-}
-
-variable "subject" {
-  type = string
-  description = "Subject line of the email"
-}
-
-variable "syntax" {
-  type = string
-  default = "liquid"
-  description = "Syntax of the template body"
-}
-
-variable "url_lifetime_in_seconds" {
-  type = number
-  default = 3600
-}
-
-variable "enable_template" {
-  type = bool
-  default = true
+variable "templates" {
+  type = map(object({
+    template                  = string
+    enabled                   = bool
+    body                      = string
+    from                      = string
+    subject                   = string
+    syntax                    = string
+    include_email_in_redirect = optional(bool)
+    result_url                = optional(string)
+    url_lifetime_in_seconds   = optional(number)
+  }))
+  description = "Configuration for email templates."
 }

--- a/modules/auth0-email/variable.tf
+++ b/modules/auth0-email/variable.tf
@@ -1,6 +1,12 @@
-variable "enable_ses_email_provider" {
+variable "enable_provider" {
   type    = bool
   default = true
+}
+
+variable "name" {
+  description = "Name of the email provider. Options include mailgun, mandrill, sendgrid, ses, smtp, and sparkpost."
+  type        = string
+  default     = null
 }
 
 variable "default_from_address" {
@@ -13,6 +19,7 @@ variable "credentials" {
     access_key_id     = string
     secret_access_key = string
     region            = string
+    api_key           = string
   })
   description = "Configuration settings for the credentials for the email provider."
 }
@@ -59,7 +66,7 @@ variable "url_lifetime_in_seconds" {
   default = 3600
 }
 
-variable "enbale_teplate" {
+variable "enable_template" {
   type = bool
   default = true
 }


### PR DESCRIPTION
With these changes an example config for Sendgrid email setup would be e.g.:

```
emails = {
  "Sendgrid" = {
    name                 = "sendgrid"
    default_from_address = "Some company <noreply@someone.somewhere>"
    api_key              = var.auth0_tf_sendgrid_api_key
    templates = {
      verify_email = {
        template = "verify_email"
        enabled  = true
        body     = ""
        from     = ""
        subject  = ""
        syntax   = "liquid"
        #include_email_in_redirect = false
        #result_url                = ""
        #url_lifetime_in_seconds   = 604800
      },
      verify_email_by_code = {
        template = "verify_email_by_code"
        enabled  = true
        body     = ""
        from     = ""
        subject  = ""
        syntax   = "html"
        #include_email_in_redirect = false
        #result_url                = ""
        #url_lifetime_in_seconds   = 604800
      },
    }
  }
}
```

Paves the way for adding support for other email providers, if the respective arguments for the `credentials` [block](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/email#nested-schema-for-credentials) and the `settings` [block](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/email#nested-schema-for-settings) are added in the module.

If the `templates` map isn't defined it will be skipped.

This needs further work (e.g. getting email body using `file()`, README updates). Let me know if you like the approach though so that I know if it makes sense to keep posting PRs here.
